### PR TITLE
Improve github action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,8 +23,16 @@ jobs:
           unsafe: true
       - name: Deploy HTML to branch
         uses: s0/git-publish-subdir-action@develop
+        if: github.event_name != 'pull_request'
         env:
           REPO: self
           BRANCH: html
           FOLDER: source/TWA/Thesis/html
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload HTML as artifact
+        id: html-upload
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v3
+        with:
+          name: html
+          path: source/TWA/Thesis/html

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Run Agda
         id: typecheck
-        uses: georgejkaye/agda-github-action@v1.0
+        uses: georgejkaye/agda-github-action@v1.2
         with:
           main-file: index.lagda.md
           source-dir: source/TWA/Thesis/


### PR DESCRIPTION
The previous version of the github action didn't properly convert markdown to html, because the agda action didn't have pandoc installed.